### PR TITLE
Fix for import when generating a function component

### DIFF
--- a/cli routes/reactComponent.js
+++ b/cli routes/reactComponent.js
@@ -17,10 +17,10 @@ const reactComponent = () => {
         if (component === "function") {
           if (folderName === "." || folderName === "") {
             const writeStream = fs.createWriteStream(`./${componentName}.js`);
-            writeStream.write(`import Reactfrom "react";
+            writeStream.write(`import React from "react";
 
 const ${componentName} = () => {
-return <div />;
+  return ();
 };
 
 export default ${componentName};`);


### PR DESCRIPTION
Just fixes a space for the import, along with maybe a more opinionated change with removing the div tag from the return. There are use cases that involve users to not need a <div>, or any jsx for that matter, so in the case they DO need it, they can add it manually, no need to boilerplate it IMO (but open to others input on this)